### PR TITLE
gestalt/get shouldn't throw an exception for false/nil values

### DIFF
--- a/src/montoux/gestalt.clj
+++ b/src/montoux/gestalt.clj
@@ -154,18 +154,21 @@ in the configuration file your environment keys should be keywords, e.g. `:devel
   *env*)
 
 (defn defined?
-  "Returns true if and only if key k is defined in the configuration map."
-  [k]
-  (when (nil? *cfg*) (reset-gestalt!))
-  (contains? (clojure.core/get *cfg* *env*) k))
-
-(defn get
-  "Returns the configuration value for keys ks."
+  "Returns true iff the sequence of keys ks is defined in the configuration map."
   [& ks]
   (when (nil? *cfg*) (reset-gestalt!))
-  (or (get-in *cfg* (concat [*env*] ks))
-      (throw (IllegalArgumentException.
-              (str "Configuration \"" (vec ks) "\" not found "
-                   "in environment " *env*)))))
+  (let [sentinel (Object.)
+        found    (get-in *cfg* (cons *env* ks) sentinel)]
+    (not (identical? sentinel found))))
 
+(defn get
+  "Returns the configuration value for the sequence of keys ks."
+  [& ks]
+  (when (nil? *cfg*) (reset-gestalt!))
+  (let [sentinel (Object.)
+        found    (get-in *cfg* (cons *env* ks) sentinel)]
+    (if (identical? sentinel found)
+      (throw (IllegalArgumentException.
+        (str "Configuration " (vec ks) " not found in environment " *env*)))
+      found)))
 


### PR DESCRIPTION
Previously `gestalt/get` returned the value it found **`or`** threw an `IllegalArgumentException`; the `or` means that if it found a falsey value, rather than returning that value, it threw. This is changed to have it return whatever it finds, and only throw when the requested keys doesn't exist in the configuration.

`gestalt/contains?` already _sort of_ had that behaviour, except that it only supported a single key, rather than a sequence of keys like you could pass to `gestalt/get`. This is changed so that you can pass the same arguments to `gestalt/contains?` as to `gestalt/get`.

Now, for keys `&ks`, if `(apply gestalt/contains? ks)` is `true`, `(apply gestalt/get ks)` will return a value, and if `(apply gestalt/contains? ks)` is `false`, `(apply gestalt/get ks)` will throw.